### PR TITLE
spec and implementation for making sure string is never longer than :leng

### DIFF
--- a/lib/truncate_html/html_truncator.rb
+++ b/lib/truncate_html/html_truncator.rb
@@ -41,7 +41,7 @@ module TruncateHtml
 
       def append_to_result(token)
         if @word_boundary
-          @truncated_html << token
+          @truncated_html << token if token.html_tag? || @chars_remaining - token.length >= 0  
         else
           @truncated_html << token[0, @chars_remaining]
         end

--- a/spec/truncate_html/html_truncator_spec.rb
+++ b/spec/truncate_html/html_truncator_spec.rb
@@ -20,6 +20,10 @@ describe TruncateHtml::HtmlTruncator do
       truncate('a b c', :length => 4, :omission => '...').should == 'a...'
     end
 
+    it "never returns a string longer than :length" do
+      truncate("test this shit", :length => 10).should == 'test...'
+    end
+
     it 'supports omissions longer than the maximum length' do
       lambda { truncate('', :length => 1, :omission => '...') }.should_not raise_error
     end
@@ -44,7 +48,7 @@ describe TruncateHtml::HtmlTruncator do
       end
 
       it 'truncates, and closes the <a>, and closes any remaining open tags' do
-        truncate(@html, :length => 14).should == '<div><ul><li>Look at <a href="foo">this...</a></li></ul></div>'
+        truncate(@html, :length => 15).should == '<div><ul><li>Look at <a href="foo">this...</a></li></ul></div>'
       end
     end
 
@@ -54,7 +58,7 @@ describe TruncateHtml::HtmlTruncator do
           @html = "<p>Look at <strong>this</strong>#{char} More words here</p>"
         end
         it 'places the punctuation after the tag without any whitespace' do
-          truncate(@html, :length => 19).should == "<p>Look at <strong>this</strong>#{char} More...</p>"
+          truncate(@html, :length => 19).should == "<p>Look at <strong>this</strong>#{char}...</p>"
         end
       end
     end


### PR DESCRIPTION
Hey Guys:

We needed to make sure that the final string, including the :omission, was always shorter than :length.  As this gem exists now, you can go over :length with the :omission text.  
Here's a topic branch with that change!

Cheers,
c^2
