### PR TITLE
Adds HtmlCounter

### DIFF
--- a/lib/app/helpers/truncate_html_helper.rb
+++ b/lib/app/helpers/truncate_html_helper.rb
@@ -6,4 +6,10 @@ module TruncateHtmlHelper
     TruncateHtml::HtmlTruncator.new(html_string).truncate(options).html_safe
   end
 
+  def count_html(html)
+    return 0 if html.nil?
+    html_string = TruncateHtml::HtmlString.new(html)
+    TruncateHtml::HtmlCounter.new(html_string).count
+  end
+
 end

--- a/lib/truncate_html.rb
+++ b/lib/truncate_html.rb
@@ -1,5 +1,6 @@
 require File.join(File.dirname(__FILE__), 'truncate_html', 'version')
 require File.join(File.dirname(__FILE__), 'truncate_html', 'html_truncator')
+require File.join(File.dirname(__FILE__), 'truncate_html', 'html_counter')
 require File.join(File.dirname(__FILE__), 'truncate_html', 'html_string')
 require File.join(File.dirname(__FILE__), 'truncate_html', 'configuration')
 require File.join(File.dirname(__FILE__), 'app', 'helpers', 'truncate_html_helper')

--- a/lib/truncate_html/html_counter.rb
+++ b/lib/truncate_html/html_counter.rb
@@ -1,0 +1,41 @@
+module TruncateHtml
+  class HtmlCounter
+
+    def initialize(original_html)
+      @original_html  = original_html
+    end
+
+    def count
+      @char_count = 0
+      @open_tags = []
+
+      @original_html.html_tokens.each { |token| process_token(token) }
+
+      @char_count
+    end
+
+    private
+
+      def process_token(token)
+        if token.html_tag?
+          if token.open_tag?
+            @open_tags << token
+          else
+            remove_latest_open_tag(token)
+          end
+        else
+          @char_count += token.length
+        end
+      end
+
+      def remove_latest_open_tag(close_tag)
+        (0...@open_tags.length).to_a.reverse.each do |index|
+          if @open_tags[index].matching_close_tag == close_tag
+            @open_tags.delete_at(index)
+            break
+          end
+        end
+      end
+
+  end
+end

--- a/spec/helpers/truncate_html_helper_spec.rb
+++ b/spec/helpers/truncate_html_helper_spec.rb
@@ -17,27 +17,54 @@ describe TruncateHtmlHelper do
   end
 
   before(:each) do
-    @html_truncator_mock = mock(TruncateHtml::HtmlTruncator)
     @original_html = '<p>foo</p>'
     @original_html.stub!(:html_safe).and_return(@original_html)
   end
 
-  it 'creates an instance of HtmlTruncator and calls truncate() on it' do
-    @html_truncator_mock.stub!(:truncate).and_return(@original_html)
-    TruncateHtml::HtmlTruncator.should_receive(:new).and_return(@html_truncator_mock)
-    truncator.truncate_html(@original_html)
+  context 'HtmlTruncator' do
+    before(:each) do
+      @html_truncator_mock = mock(TruncateHtml::HtmlTruncator)
+    end
+
+    it 'creates an instance of HtmlTruncator and calls truncate() on it' do
+      @html_truncator_mock.stub!(:truncate).and_return(@original_html)
+      TruncateHtml::HtmlTruncator.should_receive(:new).and_return(@html_truncator_mock)
+      truncator.truncate_html(@original_html)
+    end
+
+    it 'calls truncate() on the HtmlTruncator object' do
+      TruncateHtml::HtmlTruncator.stub!(:new).and_return(@html_truncator_mock)
+      @html_truncator_mock.should_receive(:truncate).with({}).once.and_return(@original_html)
+      truncator.truncate_html('foo')
+    end
   end
 
-  it 'calls truncate() on the HtmlTruncator object' do
-    TruncateHtml::HtmlTruncator.stub!(:new).and_return(@html_truncator_mock)
-    @html_truncator_mock.should_receive(:truncate).with({}).once.and_return(@original_html)
-    truncator.truncate_html('foo')
+  context 'HtmlCounter' do
+    before(:each) do
+      @html_counter_mock = mock(TruncateHtml::HtmlCounter)
+    end
+
+    it 'creates an instance of HtmlCounter and calls count() on it' do
+      @html_counter_mock.stub!(:count).and_return(3)
+      TruncateHtml::HtmlCounter.should_receive(:new).and_return(@html_counter_mock)
+      truncator.count_html(@original_html)
+    end
+
+    it 'calls count() on the HtmlCounter object' do
+      TruncateHtml::HtmlCounter.stub!(:new).and_return(@html_counter_mock)
+      @html_counter_mock.should_receive(:count).once.and_return(3)
+      truncator.count_html('foo')
+    end
   end
 
   context 'the input html is nil' do
     it 'returns an empty string' do
       truncator.truncate_html(nil).should be_empty
       truncator.truncate_html(nil).should be_kind_of(String)
+    end
+
+    it 'returns 0' do
+      truncator.count_html(nil).should be(0)
     end
   end
 

--- a/spec/truncate_html/html_counter_spec.rb
+++ b/spec/truncate_html/html_counter_spec.rb
@@ -1,0 +1,28 @@
+# Encoding: UTF-8
+require File.join(File.dirname(__FILE__), '..', 'spec_helper')
+
+describe TruncateHtml::HtmlCounter do
+
+  def count(html)
+    html_string = TruncateHtml::HtmlString.new(html)
+    TruncateHtml::HtmlCounter.new(html_string).count
+  end
+
+  it "it counts a string with no html" do
+    count("test this shit").should == 14
+  end
+
+  it 'supports empty string' do
+    lambda { count('') }.should_not raise_error
+  end
+
+  it 'treats script tags as strings with no length' do
+    html = "<p>I have a script <script type = text/javascript>document.write('lum dee dum');</script> and more text</p>"
+    count(html).should == 30
+  end
+
+  it 'counts a string with a lot of tags' do
+    html = '<div><ul><li>Look at <a href = "foo">this</a> link </li></ul></div>'
+    count(html).should == 18
+  end
+end


### PR DESCRIPTION
Adding HtmlCounter which allows the user to get the length of the string without counting the tags.

`<p>foo</p>` => 3
`<div><ul><li>Look at <a href = "foo">this</a> link </li></ul></div>` => 18

Anything inside a script tag is ignored
`<p>I have a script <script type = text/javascript>document.write('lum dee dum');</script> and more text</p>` => 30

You can call it the same way you call truncate
`TruncateHtml::HtmlCounter.new(html_string).count`

There is even a helper method for it just like truncate
`count_html(html_string)`
