### PR TITLE
allow custom word boundaries

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -36,9 +36,20 @@ like `config/initializers/truncate_html.rb`
 
 ```ruby
 TruncateHtml.configure do |config|
-  config.length       = 50
-  config.omission     = '...(continued)'
+  config.length        = 50
+  config.omission      = '...(continued)'
   config.word_boundary = false
+end
+```
+
+If you really want, you can even set a custom word boundary regexp.
+For example, to truncate at the end of the nearest sentence:
+
+```ruby
+TruncateHtml.configure do |config|
+  config.length        = 50
+  config.omission      = ''
+  config.word_boundary = /\S[\.\?\!]/
 end
 ```
 

--- a/lib/truncate_html.rb
+++ b/lib/truncate_html.rb
@@ -7,7 +7,7 @@ require File.join(File.dirname(__FILE__), 'app', 'helpers', 'truncate_html_helpe
 TruncateHtml.configure do |config|
   config.length       = 100
   config.omission     = '...'
-  config.word_boundary = true
+  config.word_boundary = /\S/
 end
 
 ActionController::Base.helper(TruncateHtmlHelper)

--- a/lib/truncate_html/html_truncator.rb
+++ b/lib/truncate_html/html_truncator.rb
@@ -21,7 +21,16 @@ module TruncateHtml
           break
         end
       end
-      @truncated_html.join
+
+      out = @truncated_html.join
+
+      if @word_boundary
+        term_regexp = Regexp.new("^.*#{@word_boundary.source}")
+        match = out.match(term_regexp)
+        match ? match[0] : out
+      else
+        out
+      end
     end
 
     private

--- a/spec/truncate_html/html_truncator_spec.rb
+++ b/spec/truncate_html/html_truncator_spec.rb
@@ -29,6 +29,12 @@ describe TruncateHtml::HtmlTruncator do
     end
   end
 
+  context 'when the word_boundary option is a custom value (for splitting on sentences)' do
+    it 'truncates to the end of the nearest sentence' do
+      truncate_html('hello there. or maybe not?', :length => 16, :omission => '', :word_boundary => /\S[\.\?\!]/).should == 'hello there.'
+    end
+  end
+
   it "includes the omission text's length in the returned truncated html" do
     truncate('a b c', :length => 4, :omission => '...').should == 'a...'
   end


### PR DESCRIPTION
Our use case for this was matching the end of the nearest sentence. I considered adding a custom option (:break_on_sentences?) but it made more sense to just stuff a regexp value in word_boundary for maximum flexibility. If this it's explicitly set to false by the user, it'll still do the right thing (original behavior preserved). Let me know what you think, thanks!
