### PR TITLE
Maintain backwards compatibility on word_boundary

### DIFF
--- a/lib/truncate_html/html_truncator.rb
+++ b/lib/truncate_html/html_truncator.rb
@@ -26,6 +26,9 @@ module TruncateHtml
       out = @truncated_html.join
 
       if @word_boundary
+        # Backwards compatibility
+        @word_boundary = TruncateHtml.configuration.word_boundary if @word_boundary.class == TrueClass
+
         term_regexp = Regexp.new("^.*#{@word_boundary.source}")
         match = out.match(term_regexp)
         match ? match[0] : out

--- a/spec/truncate_html/html_truncator_spec.rb
+++ b/spec/truncate_html/html_truncator_spec.rb
@@ -29,6 +29,12 @@ describe TruncateHtml::HtmlTruncator do
     end
   end
 
+  context 'when the word_boundary option is set to true' do
+    it 'truncates using the default word_boundary option' do
+      truncate_html('hello there. or maybe not?', :length => 16, :omission => '', :word_boundary => true).should == 'hello there. or'
+    end
+  end
+
   context 'when the word_boundary option is a custom value (for splitting on sentences)' do
     it 'truncates to the end of the nearest sentence' do
       truncate_html('hello there. or maybe not?', :length => 16, :omission => '', :word_boundary => /\S[\.\?\!]/).should == 'hello there.'


### PR DESCRIPTION
Since many people will probably pull in the new version via bundle update and not change their own code, this does a check on word_boundary to see if it's true, and if so, changes it to the default configuration.
