### PR TITLE
Removed load path tampering in gemspec.

### DIFF
--- a/truncate_html.gemspec
+++ b/truncate_html.gemspec
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require "truncate_html/version"
+require File.expand_path("../lib/truncate_html/version", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "truncate_html"


### PR DESCRIPTION
This was just used to push the lib path so that the version file could be required in a relative style, which is not needed.
