### PR TITLE
Properly avert NameError when requiring gem in non-rails environments

### DIFF
--- a/lib/truncate_html.rb
+++ b/lib/truncate_html.rb
@@ -10,4 +10,5 @@ TruncateHtml.configure do |config|
   config.word_boundary = /\S/
 end
 
-ActionController::Base.helper(TruncateHtmlHelper)
+
+ActionController::Base.helper(TruncateHtmlHelper) if defined?(ActionController)

--- a/spec/truncate_html/truncate_html_spec.rb
+++ b/spec/truncate_html/truncate_html_spec.rb
@@ -1,0 +1,15 @@
+require File.join(File.dirname(__FILE__), '..', 'spec_helper')
+
+describe TruncateHtml do
+  it "includes itself in ActionController::Base" do
+    ActionController::Base.should_receive(:helper).with(TruncateHtmlHelper)
+    load File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'lib', 'truncate_html.rb'))
+  end
+
+  it "does not error if ActionController is undefined" do
+    hide_const("ActionController")
+    expect {
+      load File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'lib', 'truncate_html.rb'))
+    }.not_to raise_error
+  end
+end


### PR DESCRIPTION
When attempting to use this gem in a sinatra project, due to the fact that ActionController is not defined `require 'truncate_html'` raises a `NameError`. This change fixes it by only attempting to send ActionController::Base a helper message if ActionController is defined.
