### PR TITLE
Ensure closing tags are appended when using custom word boundaries

### DIFF
--- a/spec/truncate_html/html_truncator_spec.rb
+++ b/spec/truncate_html/html_truncator_spec.rb
@@ -39,6 +39,10 @@ describe TruncateHtml::HtmlTruncator do
     it 'truncates to the end of the nearest sentence' do
       truncate('hello there. or maybe not?', :length => 16, :omission => '', :word_boundary => /\S[\.\?\!]/).should == 'hello there.'
     end
+
+    it 'is respectful of closing tags' do
+      truncate('<p>hmmm this <em>should</em> be okay. I think...</p>', :length => 28, :omission => '', :word_boundary => /\S[\.\?\!]/).should == "<p>hmmm this <em>should</em> be okay.</p>"
+    end
   end
 
   it "includes the omission text's length in the returned truncated html" do


### PR DESCRIPTION
This looks like it was a goof on my part when adding the custom word boundaries feature in the first place :). Added a failing test case and some code to ensure that closing tags are handled correctly.
