### PR TITLE
Support for non alphabetical unicode characters

### DIFF
--- a/lib/truncate_html/html_string.rb
+++ b/lib/truncate_html/html_string.rb
@@ -4,13 +4,12 @@ module TruncateHtml
 
     UNPAIRED_TAGS = %w(br hr img).freeze
     TAG_BODY_CHARACTERS =
-      '[[:alpha:]]' + # Match unicode alphabetical characters
+      '[[:alnum:]]' + # Match unicode alpha numberic characters
       '\p{Sc}' + # Match unicode currency characters
       '\p{So}' + # Match unicode other symbols
       '[\p{Sm}&&[^<]]' + # Match unicode math symbols except ascii <. < opens html tags.
       '[\p{Zs}&&[^\s]]' + # Match unicode space characters except \s+
-      '[0-9]' + # Match digits
-      %q(\|`~!@#\$%^&*\(\)\-_\+=\[\]{}:;'²³§",\.\/?) + # Match some special characters
+      %q(\|＾｀￣`~!@#\$%^&*\(\)\-_\+=\[\]{}:;'²³§",\.\/?) + # Match some special characters
       '[[:punct:]]' # Don't gobble up chinese punctuation characters
     REGEX = %r{
       (?:<script.*>.*<\/script>)+ # Match script tags. They aren't counted in length.

--- a/spec/truncate_html/html_truncator_spec.rb
+++ b/spec/truncate_html/html_truncator_spec.rb
@@ -209,4 +209,10 @@ This is ugly html.
     truncate('＋<br />ー<br />〜<br />＝<br />─<br />a　(double-byte space)<br />￥<br />＆<br />％<br />＃<br />＄<br />！<br />？<br />＞＜<br />・<br />／<br />「」<br />＠<br />、。', length: 100).should ==
       '＋<br />ー<br />〜<br />＝<br />─<br />a　(double-byte space)<br />￥<br />＆<br />％<br />＃<br />＄<br />！<br />？<br />＞＜<br />・<br />／<br />「」<br />＠<br />、。'
   end
+
+  it "doesn't gobble up halfwidth and fullwidth forms of unicode charecters" do
+    input = '！＂＃＄％＆＇（）＊＋，－．／０１２３４５６７８９：；＜＝＞？＠ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ［＼］＾＿｀ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ｛｜｝～｟｠｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞﾡﾢﾣﾤﾥﾦﾧﾨﾩﾪﾫﾬﾭﾮﾯﾰﾱﾲﾳﾴﾵﾶﾷﾸﾹﾺﾻﾼﾽﾾￂￃￄￅￆￇￊￋￌￍￎￏￒￓￔￕￖￗￚￛￜ￠￡￢￣￤￥￦￨￩￪￫￬￭￮0123456789'
+    output = truncate(input, length: 300)
+    output.should == input 
+  end
 end


### PR DESCRIPTION
Hi,

I've added support for some non alphabetical unicode characters like currency characters, math characters, symbols etc.

Previously, non alphabetical unicode characters were gobbled up

```
[2] pry(main)> utf8_html
=> "＋<br />ー<br />〜<br />＝<br />─<br />a　(with double-byte space)<br />￥<br />＆<br />％<br />＃<br />＄<br />！<br />？<br />＞＜<br />・<br />／<br />「」<br />＠<br />、。"
[3] pry(main)> TruncateHtml::HtmlTruncator.new(TruncateHtml::HtmlString.new(utf8_html), length: 1000).truncate
=> "<br />ー<br />〜<br /><br /><br />a(with double-byte space)<br /><br />＆<br />％<br />＃<br /><br />！<br />？<br /><br />・<br />／<br />「」<br />＠<br />、。"
```

Now

```
[2] pry(main)> utf8_html
=> "＋<br />ー<br />〜<br />＝<br />─<br />a　(with double-byte space)<br />￥<br />＆<br />％<br />＃<br />＄<br />！<br />？<br />＞＜<br />・<br />／<br />「」<br />＠<br />、。"
[3] pry(main)> TruncateHtml::HtmlTruncator.new(TruncateHtml::HtmlString.new(utf8_html), length: 1000).truncate
=> "＋<br />ー<br />〜<br />＝<br />─<br />a　(with double-byte space)<br />￥<br />＆<br />％<br />＃<br />＄<br />！<br />？<br />＞＜<br />・<br />／<br />「」<br />＠<br />、。"
```
