### PR TITLE
Adding MIT license to the gemspec.

### DIFF
--- a/truncate_html.gemspec
+++ b/truncate_html.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/hgmnz/truncate_html"
   s.summary     = %q{Uses an API similar to Rails' truncate helper to truncate HTML and close any lingering open tags.}
   s.description = %q{Truncates html so you don't have to}
+  s.license     = "MIT"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
I'm working on VersionEye and my goal is to build up a license db for RubyGems which is complete. To reduce the manual work I'm doing currently it would be awesome if this gemspec would contain the license information in future. Many Thanks.
