### PR TITLE
Adding MIT license to the gemspec.

### DIFF
--- a/truncate_html.gemspec
+++ b/truncate_html.gemspec
@@ -4,6 +4,7 @@ require File.expand_path("../lib/truncate_html/version", __FILE__)
 Gem::Specification.new do |s|
   s.name        = "truncate_html"
   s.version     = TruncateHtml::VERSION
+  s.license     = "MIT"
   s.authors     = ["Harold Giménez"]
   s.email       = ["harold.gimenez@gmail.com"]
   s.homepage    = "https://github.com/hgmnz/truncate_html"


### PR DESCRIPTION
I'm working on [VersionEye](https://www.versioneye.com/) and my goal is to build up a license db for RubyGems which is complete. To reduce the manual work I'm doing currently it would be awesome if this gemspec would contain the license information in future. Many Thanks.
