### PR TITLE
Handle whitespace more generically

### DIFF
--- a/lib/truncate_html.rb
+++ b/lib/truncate_html.rb
@@ -7,7 +7,7 @@ require File.join(File.dirname(__FILE__), 'app', 'helpers', 'truncate_html_helpe
 TruncateHtml.configure do |config|
   config.length        = 100
   config.omission      = '...'
-  config.word_boundary = /\S/
+  config.word_boundary = /(?![[:space:]])./
 end
 
 

--- a/lib/truncate_html/html_string.rb
+++ b/lib/truncate_html/html_string.rb
@@ -3,7 +3,7 @@ module TruncateHtml
   class HtmlString < String
 
     UNPAIRED_TAGS = %w(br hr img).freeze
-    REGEX = /(?:<script.*>.*<\/script>)+|<\/?[^>]+>|[[[:alpha:]][0-9]\|`~!@#\$%^&*\(\)\-_\+=\[\]{}:;'²³§",\.\/?]+|\s+|[[:punct:]]/.freeze
+    REGEX = /(?:<script.*>.*<\/script>)+|<\/?[^>]+>|[[[:alpha:]][0-9]\|`~!@#\$%^&*\(\)\-_\+=\[\]{}:;'²³§",\.\/?]+|[[:space:]]+|[[:punct:]]/.freeze
 
     def initialize(original_html)
       super(original_html)
@@ -13,9 +13,7 @@ module TruncateHtml
       scan(REGEX).map do |token|
         HtmlString.new(
           token.gsub(
-            /\n/,' ' #replace newline characters with a whitespace
-          ).gsub(
-            /\s+/, ' ' #clean out extra consecutive whitespace
+            /[[:space:]]+/, ' ' #clean out extra consecutive whitespace
           )
         )
       end

--- a/spec/truncate_html/html_string_spec.rb
+++ b/spec/truncate_html/html_string_spec.rb
@@ -9,7 +9,7 @@ describe TruncateHtml::HtmlString do
 
   describe '#html_tokens' do
     it 'returns each token in the string as an array element removing any consecutive whitespace from the string' do
-      html = '<h1>Hi there</h1> <p>This          is sweet!</p> <p> squaremeter m² </p><div>Non-breaking space here: </div>'
+      html = "<h1>Hi there</h1> <p>This          is sweet!</p> \r\n<p> squaremeter m² </p><div>Non-breaking\nspace here: </div>"
       html_string(html).html_tokens.should == ['<h1>', 'Hi', ' ', 'there', '</h1>', ' ', '<p>', 'This', ' ', 'is', ' ', 'sweet!', '</p>',
         ' ', '<p>', ' ', 'squaremeter', ' ', 'm²', ' ', '</p>', '<div>', 'Non-breaking', ' ', 'space', ' ', 'here:', ' ', '</div>']
     end

--- a/spec/truncate_html/html_string_spec.rb
+++ b/spec/truncate_html/html_string_spec.rb
@@ -9,9 +9,9 @@ describe TruncateHtml::HtmlString do
 
   describe '#html_tokens' do
     it 'returns each token in the string as an array element removing any consecutive whitespace from the string' do
-      html = '<h1>Hi there</h1> <p>This          is sweet!</p> <p> squaremeter m² </p>'
+      html = '<h1>Hi there</h1> <p>This          is sweet!</p> <p> squaremeter m² </p><div>Non-breaking space here: </div>'
       html_string(html).html_tokens.should == ['<h1>', 'Hi', ' ', 'there', '</h1>', ' ', '<p>', 'This', ' ', 'is', ' ', 'sweet!', '</p>',
-        ' ', '<p>', ' ', 'squaremeter', ' ', 'm²', ' ', '</p>']
+        ' ', '<p>', ' ', 'squaremeter', ' ', 'm²', ' ', '</p>', '<div>', 'Non-breaking', ' ', 'space', ' ', 'here:', ' ', '</div>']
     end
   end
 


### PR DESCRIPTION
This fixes the issue of non-breaking spaces being discarded, resulting in words being joined together. `\s` and `\S` only match on space (character 32). HTML often uses non-breaking spaces (character 160). A more general approach is to use `[[:space:]]` instead. According to the `Regexp` documentation, `[[:space:]]` matches "Whitespace character ([:blank:], newline, carriage return, etc.)"

Fixes https://github.com/hgmnz/truncate_html/issues/68
